### PR TITLE
Add WelcomeMessage resource and some utils

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,10 +24,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>

--- a/backend/src/main/java/pk/pz/ultigrade/UltigradeApplication.java
+++ b/backend/src/main/java/pk/pz/ultigrade/UltigradeApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class UltigradeApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(UltigradeApplication.class, args);
-    }
+
+    public static void main(String[] args) { SpringApplication.run(UltigradeApplication.class, args);}
 
 }

--- a/backend/src/main/java/pk/pz/ultigrade/controllers/WelcomeController.java
+++ b/backend/src/main/java/pk/pz/ultigrade/controllers/WelcomeController.java
@@ -1,0 +1,23 @@
+package pk.pz.ultigrade.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import pk.pz.ultigrade.structures.WelcomeMessageStructure;
+import pk.pz.ultigrade.util.LocaleUtils;
+
+import java.util.List;
+import java.util.Locale;
+
+@RestController
+public class WelcomeController {
+
+    @GetMapping("/welcome")
+    public WelcomeMessageStructure WelcomeMessage(
+            @RequestHeader(name = "Accept-Language", required = false, defaultValue = "en-us") String acceptedLanguage
+    ){
+        List<Locale.LanguageRange> list = Locale.LanguageRange.parse(acceptedLanguage);
+        Locale locale = new Locale(LocaleUtils.getTheBest(list).getRange());
+        return new WelcomeMessageStructure(locale);
+    }
+}

--- a/backend/src/main/java/pk/pz/ultigrade/structures/WelcomeMessageStructure.java
+++ b/backend/src/main/java/pk/pz/ultigrade/structures/WelcomeMessageStructure.java
@@ -1,0 +1,27 @@
+package pk.pz.ultigrade.structures;
+
+import pk.pz.ultigrade.util.LocalizedWelcomeMessages;
+import pk.pz.ultigrade.util.RandomUtils;
+
+import java.util.Locale;
+
+public class WelcomeMessageStructure {
+
+    public String welcomeMessage;
+    public long currentTimeMillis;
+
+    public WelcomeMessageStructure(String s){
+        welcomeMessage = s;
+        currentTimeMillis = System.currentTimeMillis();
+    }
+
+    public WelcomeMessageStructure(Locale locale){
+        this(getRandomWelcomeMessage(locale));
+    }
+
+    private static String getRandomWelcomeMessage(Locale locale){
+        String[] list = LocalizedWelcomeMessages.getInstance().getLocalized(locale);
+        return RandomUtils.randomElement(list);
+    }
+
+}

--- a/backend/src/main/java/pk/pz/ultigrade/util/LocaleUtils.java
+++ b/backend/src/main/java/pk/pz/ultigrade/util/LocaleUtils.java
@@ -1,0 +1,22 @@
+package pk.pz.ultigrade.util;
+
+import java.util.List;
+import java.util.Locale;
+
+public class LocaleUtils {
+
+    public static Locale.LanguageRange getTheBest(List<Locale.LanguageRange> list){
+        Locale.LanguageRange best = list.get(0);
+        for(Locale.LanguageRange lr : list){
+            if(best.getWeight() < lr.getWeight())
+                best = lr;
+        }
+        return best;
+    }
+
+
+    private LocaleUtils(){
+    }
+
+
+}

--- a/backend/src/main/java/pk/pz/ultigrade/util/LocalizedWelcomeMessages.java
+++ b/backend/src/main/java/pk/pz/ultigrade/util/LocalizedWelcomeMessages.java
@@ -1,0 +1,74 @@
+package pk.pz.ultigrade.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ResourceUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Locale;
+
+
+public class LocalizedWelcomeMessages {
+    private static final Logger logger = LoggerFactory.getLogger(LocalizedWelcomeMessages.class);
+
+    private static final String WELCOME_MESSAGE_FILE_PATH = "datafiles/WelcomeMessages";
+    private static final Locale DEFAULT_LOCALE = Locale.US;
+
+    private final HashMap<String, String[]> list;
+
+    private static LocalizedWelcomeMessages instance;
+    public static synchronized LocalizedWelcomeMessages getInstance(){
+        if(instance == null)
+            instance = new LocalizedWelcomeMessages();
+        return instance;
+    }
+
+    private LocalizedWelcomeMessages(){
+        list = new HashMap<String, String[]>();
+    }
+
+    public String[] getLocalized(Locale locale){
+        return getLocalized(locale, false);
+    }
+
+    public String[] getLocalized(Locale locale, boolean preventDefault){
+        String tag = locale.getLanguage();
+        String[] localized = list.get(tag);
+        if(localized == null) {
+            localized = initializeLocalized(tag);
+            if (localized == null)
+                localized = preventDefault ? null : getDefault();
+        }
+
+        return localized;
+    }
+
+    public String[] getDefault(){
+        String[] lines = getLocalized(DEFAULT_LOCALE, true);
+        if(lines == null) {
+            lines = new String[]{"Remember to always put localized files in your project..."};
+            list.put(DEFAULT_LOCALE.toLanguageTag(), lines);
+        }
+        return lines;
+    }
+
+    private String[] initializeLocalized(String tag){
+        try {
+            URI path = ResourceUtils.getFile("classpath:" + WELCOME_MESSAGE_FILE_PATH + "." + tag + ".txt").toURI();
+            String[] lines = Files.readAllLines(Path.of(path)).toArray(new String[0]);
+            if(lines.length != 0){
+                list.put(tag, lines);
+                logger.info("Initialized welcome messages for " + tag);
+                return lines;
+            }
+        }
+        catch (IOException ignored){}
+        logger.info("Failed to initialize welcome messages for " + tag);
+        return null;
+    }
+
+}

--- a/backend/src/main/java/pk/pz/ultigrade/util/RandomUtils.java
+++ b/backend/src/main/java/pk/pz/ultigrade/util/RandomUtils.java
@@ -1,0 +1,34 @@
+package pk.pz.ultigrade.util;
+
+import java.util.Random;
+
+public class RandomUtils {
+    private static final Random random = new Random();
+
+
+    public static <T> T randomElement(T[] list){
+        int randomIndex = random.nextInt(list.length);
+        return list[randomIndex];
+    }
+
+    public static int randomInt(int max){
+        return randomInt(0, max);
+    }
+    public static int randomInt(int min, int max){
+        return random.nextInt(max - min) + min;
+    }
+
+    public static float randomFloat(){
+        return random.nextFloat();
+    }
+    public static float randomFloat(int max){
+        return randomFloat(0, max);
+    }
+    public static float randomFloat(int min, int max){
+        return random.nextFloat() * (max - min) + min;
+    }
+
+    private RandomUtils(){
+    }
+
+}

--- a/backend/src/main/resources/datafiles/WelcomeMessages.en.txt
+++ b/backend/src/main/resources/datafiles/WelcomeMessages.en.txt
@@ -1,0 +1,1 @@
+Welcome

--- a/backend/src/main/resources/datafiles/WelcomeMessages.pl.txt
+++ b/backend/src/main/resources/datafiles/WelcomeMessages.pl.txt
@@ -1,0 +1,5 @@
+Dzień dobry!
+To dobry dzień na egzamin!
+Siema!
+Proszę włączyć kamerki
+Pani od przyrki znowu dała dużo zadań?


### PR DESCRIPTION
Dodaje prosty resource do testów połączeń na froncie.


# GET `/welcome`
## Headers:
- `Accept-Language` (optional, default="en")

## Response:
```
{
  welcomeMessage,
  currentTimeMillis
}
```

`welcomeMessage` : `string` - losowa wiadomość powitalna  
`currentTimeMillis` : `long` - aktualny czas serwera wyrażony w milisekundach